### PR TITLE
feat: add longhorn storage

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cert-manager
+  - ./default
+  - ./flux-system
+  - ./kube-system
+  - ./longhorn-system
+  - ./network

--- a/kubernetes/apps/longhorn-system/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: longhorn-system
+components:
+  - ../../components/common
+resources:
+  - ./longhorn/ks.yaml

--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1beta2.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:

--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
     name: longhorn
   install:
     remediation:
-      retries: -1
+      retries: 5
   upgrade:
     cleanupOnFail: true
     remediation:

--- a/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/helmrelease.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/ocirepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: longhorn
+spec:
+  interval: 5m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://ghcr.io/longhorn/charts/longhorn
+  ref:
+    tag: 1.9.1
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: longhorn
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: longhorn
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    fullnameOverride: longhorn
+    persistence:
+      defaultClass: true
+      defaultClassReplicaCount: 2
+    defaultSettings:
+      defaultReplicaCount: 2
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/apps/longhorn-system/longhorn/app/httproute.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/httproute.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://github.com/datreeio/CRDs-catalog/raw/refs/heads/main/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: longhorn
+spec:
+  hostnames: ["longhorn.${SECRET_DOMAIN}"]
+  parentRefs:
+    - name: internal
+      namespace: kube-system
+      sectionName: https
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: longhorn-frontend
+          port: 80

--- a/kubernetes/apps/longhorn-system/longhorn/app/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/longhorn-system/longhorn/ks.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/ks.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app longhorn
+  namespace: &namespace longhorn-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  interval: 1h
+  path: ./kubernetes/apps/longhorn-system/longhorn/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary
- add root kustomization for apps including new longhorn namespace
- deploy longhorn via HelmRelease with default settings
- expose longhorn UI at `longhorn.${SECRET_DOMAIN}` via internal HTTPS gateway

## Testing
- `/root/.local/share/mise/installs/task/3.44.1/task -l`


------
https://chatgpt.com/codex/tasks/task_e_68b3d7ef47bc832dbf345fbba5ff5cf4